### PR TITLE
Update job-dsl-core to 1.28 and enable IDE support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'groovy'
 
+sourceSets {
+    jobs {
+        groovy {
+            srcDirs 'jobs'
+        }
+    }
+}
+
 repositories {
     mavenCentral()
     maven { url 'http://repo.jenkins-ci.org/releases/' }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     compile 'org.codehaus.groovy:groovy:2.1.3'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.20'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.28'
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
     }

--- a/jobs/gradleJobs.groovy
+++ b/jobs/gradleJobs.groovy
@@ -1,4 +1,5 @@
 import com.dslexample.GradleCiJobBuilder
+import javaposse.jobdsl.dsl.DslFactory
 
 List developers = ['dev3@example.com', 'dev4@example.com']
 String gitUrl = 'git@github.com:example/example.git'
@@ -9,7 +10,7 @@ new GradleCiJobBuilder(
         gitUrl: 'git@github.com:example/example.git',
         tasks: 'clean test',
         mailerRecipients: ['dev1@example.com']
-).build(this)
+).build(this as DslFactory)
 
 new GradleCiJobBuilder(
         name: 'another-example-gradle-job',
@@ -17,7 +18,7 @@ new GradleCiJobBuilder(
         gitUrl: 'git@github.com:example/example2.git',
         tasks: 'clean test',
         mailerRecipients: ['dev1@example.com', 'dev2@example.com']
-).build(this)
+).build(this as DslFactory)
 
 [
         [name: 'yet-another-example-gradle-job', description: 'Example job description'],

--- a/jobs/grailsJobs.groovy
+++ b/jobs/grailsJobs.groovy
@@ -1,4 +1,5 @@
 import com.dslexample.GrailsCiJobBuilder
+import javaposse.jobdsl.dsl.DslFactory
 
 job {
     name 'example-job'
@@ -14,10 +15,10 @@ new GrailsCiJobBuilder(
     name: 'example-grails-job',
     description: 'An example using a job builder for a Grails project.',
     gitUrl: 'git@github.com:example/example.git'
-).build(this)
+).build(this as DslFactory)
 
 new GrailsCiJobBuilder(
     name: 'another-example-grails-job',
     description: 'Another example using a job builder for a Grails project.',
     gitUrl: 'git@github.com:example/example2.git'
-).build(this)
+).build(this as DslFactory)

--- a/src/main/groovy/com/dslexample/GradleCiJobBuilder.groovy
+++ b/src/main/groovy/com/dslexample/GradleCiJobBuilder.groovy
@@ -1,5 +1,6 @@
 package com.dslexample
 
+import javaposse.jobdsl.dsl.DslFactory
 import javaposse.jobdsl.dsl.Job
 
 /**
@@ -19,8 +20,8 @@ class GradleCiJobBuilder {
     String artifacts = '**/build/libs/*.jar'
     List mailerRecipients = []
 
-    Job build(jobParent) {
-        jobParent.job {
+    Job build(DslFactory dslFactory) {
+        dslFactory.job {
             it.name this.name
             it.description this.description
             logRotator(-1, 5, -1, -1)

--- a/src/main/groovy/com/dslexample/GrailsCiJobBuilder.groovy
+++ b/src/main/groovy/com/dslexample/GrailsCiJobBuilder.groovy
@@ -1,5 +1,6 @@
 package com.dslexample
 
+import javaposse.jobdsl.dsl.DslFactory
 import javaposse.jobdsl.dsl.Job
 
 /**
@@ -11,8 +12,8 @@ class GrailsCiJobBuilder {
     String description
     String gitUrl
 
-    Job build(jobParent) {
-        jobParent.job {
+    Job build(DslFactory dslFactory) {
+        dslFactory.job {
             it.name this.name
             it.description this.description
             logRotator(-1, 5, -1, -1)

--- a/src/test/groovy/com/dslexample/JobSpecMixin.groovy
+++ b/src/test/groovy/com/dslexample/JobSpecMixin.groovy
@@ -1,16 +1,22 @@
 package com.dslexample
 
+import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobParent
 
 
 class JobSpecMixin {
 
     JobParent createJobParent() {
-        new JobParent() {
+        JobParent jp = new JobParent() {
             @Override
             Object run() {
                 return null
             }
         }
+        JobManagement jm = [
+                getPluginVersion: { String pluginShortName -> null },
+        ] as JobManagement
+        jp.setJm(jm)
+        jp
     }
 }


### PR DESCRIPTION
To enable IDE support I had to make some changes:

* declare jobs folder as source folder in build.gradle
* renamed job scripts to be valid identifier names (IDE support does not work otherwise)
* moved job scripts to root package to avoid missing package name warning in IDEA (though it is still possible to use packages for job scripts)
* use DslFactory to enable IDE support in builder classes