### PR TITLE
Move all jobs into a single parent folder

### DIFF
--- a/jobs/example1Jobs.groovy
+++ b/jobs/example1Jobs.groovy
@@ -1,4 +1,4 @@
-String basePath = 'example1'
+String basePath = 'job-dsl-gradle-example/example1'
 String repo = 'sheehan/grails-example'
 
 folder(basePath) {

--- a/jobs/example2Jobs.groovy
+++ b/jobs/example2Jobs.groovy
@@ -1,6 +1,6 @@
 import groovy.json.JsonSlurper
 
-String basePath = 'example2'
+String basePath = 'job-dsl-gradle-example/example2'
 String repo = 'sheehan/grails-example'
 
 folder(basePath) {

--- a/jobs/example3Jobs.groovy
+++ b/jobs/example3Jobs.groovy
@@ -1,4 +1,4 @@
-String basePath = 'example3'
+String basePath = 'job-dsl-gradle-example/example3'
 
 folder(basePath) {
     description 'This example shows how to use the configure block.'

--- a/jobs/example4Jobs.groovy
+++ b/jobs/example4Jobs.groovy
@@ -1,4 +1,4 @@
-String basePath = 'example4'
+String basePath = 'job-dsl-gradle-example/example4'
 
 folder(basePath) {
     description 'This example shows a way to reuse job definitions for jobs that differ only with a few properties.'

--- a/jobs/example5Jobs.groovy
+++ b/jobs/example5Jobs.groovy
@@ -1,6 +1,6 @@
 import com.dslexample.StepsUtil
 
-String basePath = 'example5'
+String basePath = 'job-dsl-gradle-example/example5'
 
 folder(basePath) {
     description 'This example shows how to pull out common components into static methods.'

--- a/jobs/example6Jobs.groovy
+++ b/jobs/example6Jobs.groovy
@@ -1,4 +1,4 @@
-String basePath = 'example6'
+String basePath = 'job-dsl-gradle-example/example6'
 
 folder(basePath) {
     description 'This example shows how to include script resources from the workspace.'

--- a/jobs/example7Jobs.groovy
+++ b/jobs/example7Jobs.groovy
@@ -1,7 +1,7 @@
 import com.dslexample.GradleCiJobBuilder
 import com.dslexample.GrailsCiJobBuilder
 
-String basePath = 'example7'
+String basePath = 'job-dsl-gradle-example/example7'
 List developers = ['dev1@example.com', 'dev2@example.com']
 
 folder(basePath) {

--- a/jobs/seed.groovy
+++ b/jobs/seed.groovy
@@ -1,7 +1,13 @@
 // If you want, you can define your seed job in the DSL and create it via the REST API.
 // See https://github.com/sheehan/job-dsl-gradle-example#rest-api-runner
 
-job('seed') {
+String basePath = 'job-dsl-gradle-example'
+
+folder(basePath) {
+    description 'Examples for Job DSL with Gradle build'
+}
+
+job("$basePath/seed") {
     scm {
         github 'sheehan/job-dsl-gradle-example'
     }


### PR DESCRIPTION
I find it more convenient to keep all the example jobs in a single folder.  I guess the downside is this makes the example dependent on the Cloudbees Folders Plugin.