### PR TITLE
Fix test task inputs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     compile('ant:ant:1.7.0')
 }
 
+tasks.getByName('test').inputs.files(sourceSets.jobs.groovy.srcDirs)
+
 task rest(dependsOn: 'classes', type: JavaExec) {
     main = 'com.dslexample.rest.RestApiScriptRunner'
     classpath = sourceSets.main.runtimeClasspath


### PR DESCRIPTION
The test task inputs were not including the actual jobs files. The resulting problem is that changing a job file and re-running the test task was causing Gradle to simply show UP-TO-DATE. This is annoying because develop & test cycle is broken. Moreover, the continuous build option could not work correctly due to task inputs not including the jobs files.

Fixed by adding jobs groovy source set source directories to test task inputs.