### PR TITLE
Add Travis-CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: groovy
+jdk:
+  - openjdk7
+  - oraclejdk8
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
This just adds the configuration to run tests on Travis-CI, you still have to activate it on https://travis-ci.org/.

It curently runs tests against OpenJDK7 and OracleJDK8.

I enabled the caches for Gradle as described on https://docs.travis-ci.com/user/languages/groovy - see https://travis-ci.org/TobiX/job-dsl-gradle-example/builds/142315289 for a sample build, the OpenJDK7 build was running with cache, the OracleJDK8 build without, so the cache provides a nice speedup.