### PR TITLE
Make jobs sourceSet depend on main sourceSet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ sourceSets {
         groovy {
             srcDirs 'jobs'
         }
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
     }
 }
 


### PR DESCRIPTION
This way intellij can resolve import com.dslexample.StepsUtil in example 5.
Somewhat similar to what 'additionalClasspath 'src/main/groovy'' in seed.groovy does for jenkins.