### PR TITLE
Make example robust to spaces in the job / folder names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ configurations {
     testPlugins {}
 }
 
+// Exclude buggy Xalan dependency this way the JRE default TransformerFactory is used
+// The xalan pulled in by htmlunit does not properly deal with spaces folder / job names
+configurations.all*.exclude group: 'xalan'
+
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.7'
     compile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"

--- a/jobs/example1Jobs.groovy
+++ b/jobs/example1Jobs.groovy
@@ -5,7 +5,7 @@ folder(basePath) {
     description 'This example shows basic folder/job creation.'
 }
 
-job("$basePath/grails-example-build") {
+job("$basePath/grails example build") {
     scm {
         github repo
     }
@@ -20,7 +20,7 @@ job("$basePath/grails-example-build") {
     }
 }
 
-job("$basePath/grails-example-deploy") {
+job("$basePath/grails example deploy") {
     parameters {
         stringParam 'host'
     }


### PR DESCRIPTION
The dependencies of the jenkins-test-harness pull in a version of Xalan that improperly converts file URL's (it strips off the file:// part but does not URL decode the path itself). This PR excludes xalan dependencies so things will fall back to the one present in the JRE and also changes one of the examples to have spaces in the job name.

Without this change you will get exceptions like the following, if a job or folder contains spaces (or other URL encoded values) in the name:

```
WARNING: Error writing config for new item example1/grails example build.
java.io.IOException: Failed to persist config.xml
...<snip>...
Caused by: javax.xml.transform.TransformerException: java.io.FileNotFoundException: /tmp/hudson1941086893420576676test/jobs/example1/jobs/grails%20example%20build/config.xml (No such file or directory)
	at org.apache.xalan.transformer.TransformerIdentityImpl.createResultContentHandler(TransformerIdentityImpl.java:297)
	at org.apache.xalan.transformer.TransformerIdentityImpl.transform(TransformerIdentityImpl.java:330)
	at jenkins.util.xml.XMLUtils._transform(XMLUtils.java:96)
	at jenkins.util.xml.XMLUtils.safeTransform(XMLUtils.java:63)
	at hudson.model.ItemGroupMixIn.createProjectFromXML(ItemGroupMixIn.java:266)
	... 127 more
Caused by: java.io.FileNotFoundException: /tmp/hudson1941086893420576676test/jobs/example1/jobs/grails%20example%20build/config.xml (No such file or directory)
	at java.io.FileOutputStream.open0(Native Method)
	at java.io.FileOutputStream.open(FileOutputStream.java:270)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:101)
	at org.apache.xalan.transformer.TransformerIdentityImpl.createResultContentHandler(TransformerIdentityImpl.java:287)
	... 131 more
```
