### PR TITLE
Add missing cvs option 'checkoutCurrentTimestamp'

### DIFF
--- a/jobs/example9Jobs.groovy
+++ b/jobs/example9Jobs.groovy
@@ -13,6 +13,7 @@ job("$basePath/grails-legacy-build") {
                     cvsRoot repo
                     passwordRequired false
                     password null
+                    checkoutCurrentTimestamp false
                     compressionLevel(-1)
                     repositoryBrowser {}
                     repositoryItems {


### PR DESCRIPTION
Fixes error: 'ERROR: (example9Jobs.groovy, line 10) the following
options are required and must be specified: checkoutCurrentTimestamp'
when running ezmple 9 with CVS plugin v2.13.