### PR TITLE
[JENKINS-48877] war-for-test classifier is not supported from 2.64+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,11 +33,10 @@ dependencies {
     testCompile 'cglib:cglib-nodep:2.2.2' // used by Spock
 
     // Jenkins test harness dependencies
-    testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.22'
+    testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.33'
     testCompile("org.jenkins-ci.main:jenkins-war:${jenkinsVersion}") {
         exclude group: 'org.jenkins-ci.ui', module: 'bootstrap' // https://github.com/sheehan/job-dsl-gradle-example/issues/87
     }
-    testCompile "org.jenkins-ci.main:jenkins-war:${jenkinsVersion}:war-for-test@jar"
 
     // Job DSL plugin including plugin dependencies
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}"


### PR DESCRIPTION
[JENKINS-48877](https://issues.jenkins-ci.org/browse/JENKINS-48877)

Bumped jenkins-test-harness and also removed the war-for-test classifier as required since version 2.64 onwards

Further details:
- https://groups.google.com/forum/#!topic/job-dsl-plugin/oPjqGR6VTpU
  