### PR TITLE
updated job-dsl-core to 1.68

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ configurations {
 configurations.all*.exclude group: 'xalan'
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.8'
+    compile 'org.codehaus.groovy:groovy-all:2.4.11'
     compile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"
 
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
@@ -43,7 +43,7 @@ dependencies {
     // Job DSL plugin including plugin dependencies
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}"
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}@jar"
-    testCompile 'org.jenkins-ci.plugins:structs:1.9@jar'
+    testCompile 'org.jenkins-ci.plugins:structs:1.13@jar'
     testCompile 'org.jenkins-ci.plugins:cloudbees-folder:5.12@jar'
 
     // plugins to install in test instance

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-jobDslVersion=1.67
-jenkinsVersion=2.5
+jobDslVersion=1.68
+jenkinsVersion=2.73


### PR DESCRIPTION
The Grails plugin has been suspended from distribution in Update Center due to security issues. Support in Job DSL has been removed in 1.68. So **many of the tests will fail with 1.68**.

IMHO we should change the examples to use something different than the Grails plugin. Any ideas? Shall we use the Gradle plugin examples only?