### PR TITLE
Install required dependencies for auto generated ghprb dsl examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ configurations.all*.exclude group: 'xalan'
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.11'
     compile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"
+    compile 'org.kohsuke:github-api:1.93'
 
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testCompile 'cglib:cglib-nodep:2.2.2' // used by Spock
@@ -45,16 +46,21 @@ dependencies {
     testCompile "org.jenkins-ci.plugins:job-dsl:${jobDslVersion}@jar"
     testCompile 'org.jenkins-ci.plugins:structs:1.13@jar'
     testCompile 'org.jenkins-ci.plugins:cloudbees-folder:5.12@jar'
+    testCompile 'org.jenkins-ci.plugins:ghprb:1.40.0@jar'
+    testCompile 'org.jenkins-ci.plugins:credentials:2.1.10@jar'
+    testCompile 'com.coravy.hudson.plugins.github:github:1.29.0@jar'
 
     // plugins to install in test instance
-    testPlugins 'org.jenkins-ci.plugins:ghprb:1.31.4'
-    testPlugins 'com.coravy.hudson.plugins.github:github:1.19.0'
+    testPlugins 'org.jenkins-ci.plugins:ghprb:1.40.0'
     testPlugins 'org.jenkins-ci.plugins:cloudbees-folder:5.12'
     testPlugins 'org.jenkins-ci.plugins:credentials:2.1.10'
 
     // plugins used for auto-generated DSL. See example 9.
     testPlugins 'org.jenkins-ci.plugins:cvs:2.13'
     testPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:2.7'
+
+    // plugin dependencies
+    testPlugins 'org.jenkins-ci.plugins:token-macro:2.5'
 }
 
 task resolveTestPlugins(type: Copy) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 14 16:48:17 CST 2017
+#Thu May 10 15:25:56 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip


### PR DESCRIPTION
This installs all kind of dependenies so that newer version of GHPRB work again and also installs plugins to remove error output from the test output.

This closes #98 and jenkins-ci/ghprb-plugin#640