### PR TITLE
fixes build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ sourceSets {
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.jenkins-ci.org/releases/' }
+    maven { url 'https://repo.jenkins-ci.org/releases/' }
     jcenter()
 }
 


### PR DESCRIPTION
I cloned this example repo but gradle test is failing with below error

`job-dsl-gradle-example root# ./gradlew test
Starting a Gradle Daemon (subsequent builds will be faster)
Download http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/job-dsl-core/1.59/job-dsl-core-1.59.pom

> Task :compileGroovy
[Fatal Error] job-dsl-core-1.59.pom:7:3: The element type "hr" must be terminated by the matching end-tag "</hr>".

> Task :compileGroovy FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':compileClasspath'.
> Could not resolve org.jenkins-ci.plugins:job-dsl-core:1.59.
  Required by:
      project :
   > Could not resolve org.jenkins-ci.plugins:job-dsl-core:1.59.
      > Could not parse POM http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/job-dsl-core/1.59/job-dsl-core-1.59.pom
         > The element type "hr" must be terminated by the matching end-tag "</hr>".

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 15s
1 actionable task: 1 executed`

This PR fixes this build failure issue